### PR TITLE
Bug Fixes

### DIFF
--- a/treeview/index.html
+++ b/treeview/index.html
@@ -11,8 +11,9 @@
 
 <body>
     <div class="row">
-        <!-- <div id="left" class="col-md-2 col-lg-2 col-sm-2 col-2" style="@media (max-width:250px)">
-            <div id="look-up" style="height:100%;overflow:auto;border-right: solid 1px #2e6da4;">
+      <!-- @media (max-width:250px) -->
+        <div id="left" class="col-md-2 col-lg-2 col-sm-2 col-2" style="@media (max-width:250px)">
+            <div id="look-up" style="overflow:auto;border-right: solid 1px #2e6da4;">
                 <div class="panel-group" id="accordion">
                     <div class="panel panel-default">
                         <div class="panel-heading">
@@ -144,32 +145,35 @@
                     </div>
                 </div>
             </div>
-        </div> -->
-        <div id="right" class="col-md-10 col-lg-10 col-sm-10 col-10" style="margin-left:10px;">
+        </div>
+        <div id="right" class="col-md-10 col-lg-10 col-sm-10 col-10">
             <div class="tree-panel" style="height:100%;overflow:auto;">
-                <div id="mouseAnatomyHeading" style="margin-left:6px;">
+                <div id="mouseAnatomyHeading" style="margin-left:6px;visibility:hidden;">
                     <h3>Mouse Anatomy Tree</h3>
                 </div>
-                <div id="TSDropdownDiv" style="display:inline;visibility:hidden;">
+                <div id="parent">
+                  <div id="TSDropdownDiv" style="display:inline;visibility:hidden;">
                     <select name="number" id="number">
                     </select>
-                </div>
-                <div id="mainDiv" class="input-group has-feedback" style="display:inline;visibility:hidden;">
-                    <div style="position:relative; display:table; border-collapse:separate;">
-                        <input type="text" id="plugins4_q" value="" class="input form-control" style="display:inline; margin:0em 0em 0em 0.5em; padding:4px; border-radius:4px; border:1px solid silver;width: 22em;margin-top: 1em" placeholder="Search"></input>
-                        <div class="form-control-feedback" style="cursor:pointer; right:-4px; top:25px; pointer-events:all; z-index:5;">
-                            <span class="glyphicon glyphicon-remove" id="reset_text"></span>
-                        </div>
-                    </div>
-                    <span class="input-group-btn" style="top:-33px; left:316px;">
-					          <button type="button" id="search_btn" class="btn btn-primary btn-inverted">
-					              <span class="glyphicon glyphicon-search"></span>
-                    </button>
-                    <button type="button" id="expand_all_btn" class="btn btn-primary btn-inverted">Expand All</button>
-                    <button type="button" id="collapse_all_btn" class="btn btn-primary btn-inverted" style="display: inline;">Collapse All</button>
-                    </span>
-                </div>
-                <div class="loader"></div>
+                  </div>
+                  <div id="mainDiv" class="input-group has-feedback" style="display:inline;visibility:hidden;">
+                      <div style="position:relative; display:table; border-collapse:separate;">
+                          <input type="text" id="plugins4_q" value="" class="input form-control" style="display:inline; margin:0em 0em 0em 0.5em; padding:4px; border-radius:4px; border:1px solid #2e6da4; border-right: none; border-radius: 0;width: 22em; height: 33px;margin-top: 1em" placeholder="Search"></input>
+                          <div class="form-control-feedback" style="cursor:pointer; right:-4px; top:25px; pointer-events:all; z-index:5;">
+                              <span class="glyphicon glyphicon-remove" id="reset_text"></span>
+                          </div>
+                      </div>
+                      <span class="input-group-btn" style="top:-33px; left:316px;">
+    					          <button type="button" id="search_btn" class="btn btn-primary btn-inverted">
+    					              <span class="glyphicon glyphicon-search"></span>
+                        </button>
+                        <button type="button" id="expand_all_btn" class="btn btn-primary btn-inverted" style="margin-left:3px;">Expand All</button>
+                        <button type="button" id="collapse_all_btn" class="btn btn-primary btn-inverted" style="display: inline;border-radius:0;">Collapse All</button>
+                      </span>
+                  </div>
+              </div>
+                <p class="error" id="error-message" style="visibility:hidden;margin-left:5px;"></p>
+                <div class="loader" id="loadIcon" style="visibility:hidden;"></div>
                 <div id="jstree" style="visibility: hidden;">
                     <!-- in this example the tree is populated from inline HTML -->
                 </div>

--- a/treeview/themes/default/images/style.css
+++ b/treeview/themes/default/images/style.css
@@ -1,5 +1,35 @@
 /* jsTree default theme */
 
+#left {
+  visibility: hidden;
+  padding-right: 0px;
+}
+
+#right{
+  padding-left: 0px;
+}
+
+.tree-panel{
+  padding-left: 20px;
+}
+
+#parent {
+  display: flex;
+}
+#TSDropdownDiv {
+  width: 6em;
+  margin-top: 1em;
+  margin-right: 4px;
+  /* Just so it's visible */
+}
+#mainDiv {
+  flex: 1;
+  /* Grow to rest of container */
+}
+
+.jstree-grid-wrapper{
+  overflow: hidden!important;
+}
 .back-to-top {
     background: none;
     margin: 0;
@@ -11,6 +41,8 @@
     z-index: 100;
     display: none;
     text-decoration: none;
+    margin-right: 20px;
+    margin-bottom: 16px;
 }
 
 .overflow {
@@ -18,16 +50,20 @@
 }
 
 .ui-selectmenu-button.ui-button {
-    width: 22em !important
+  width: 6em !important;
+  height: 2.38em;
+  border-radius: 0;
+  border:1px solid #2e6da4;
 }
 
 span#number-button {
     margin-left: 8px;
+    padding-left: 1em;
 }
 
 .btn-primary {
     background-color: #337ab7;
-    height: 2.3em;
+    height: 2.35em;
 }
 
 .btn-primary.btn-inverted {


### PR DESCRIPTION
Remove comments in code to include logic for "specimen_rid" in url.
Change description to name attribute in drop down.
Change style of drop down to make it inline with the input and other 
buttons.
Style of input and action group items modified.
Disable stage and display data for the stage corresponding to 
"specimen_rid" in url.
In case of "specimen_rid", focus on the term with annotation on load of 
tree.
Error handling in case there is no stage associated with the 
specimen_rid.
Double scroll bar issue fixed.
Scroll bar shift to right issue fixed