### PR TITLE
added navbar to the treeview

### DIFF
--- a/treeview/index.html
+++ b/treeview/index.html
@@ -5,8 +5,12 @@
     <link rel="stylesheet" href="../../chaise/styles/vendor/bootstrap.css">
     <!-- issue with using out own jquery-ui css is that it will be missing icons/images that have a relative path on jquery website -->
     <!-- <link rel="stylesheet" href="resources/styles/jquery-ui.css"> -->
+    <script src="../../chaise/scripts/vendor/angular.js"></script>
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <script src="../../chaise/scripts/vendor/jquery-3.3.1.min.js"></script>
+    <script src="../../chaise/chaise-config.js"></script>
+
+    <script src="../../chaise/lib/navbar/navbar.app.js"></script>
     <script src="util/jquery-ui.js"></script>
     <script src="util/jstree.js"></script>
     <script src="util/jstreegrid.js"></script>
@@ -19,6 +23,7 @@
 </head>
 
 <body>
+    <navbar></navbar>
     <div id="schematic-modal" class="modal fade" tabindex="-1" role="dialog">
         <div class="modal-dialog" role="document">
             <div class="modal-content">

--- a/treeview/js/main.js
+++ b/treeview/js/main.js
@@ -246,7 +246,8 @@
 
 
                 // Show the navbar if static and not embedded in boolean search
-                if ((!showAnnotation && !parentAppExists) || urlParams.showNavbar == "true") {
+                // urlParams.Navbar will be used only if it is set to a boolean value (`true` or `false`)
+                if ((!showAnnotation && !parentAppExists && urlParams.Navbar != "false") || urlParams.Navbar == "true") {
                     // property has to be "unset" (which stores a value) rather than trying to apply .css("display, "")
                     // applying .css("display", "") actually removes the property definition and then the property defined in the CSS document is applied
                     $("navbar")[0].style.display = "unset";

--- a/treeview/js/main.js
+++ b/treeview/js/main.js
@@ -214,17 +214,15 @@
             function setupDomElements() {
                 // NOTE: should this always be the last param in treeviewConfig.filters[last].selected_filter.required_url_parameters?
                 var idParamName = requiredParams[requiredParams.length-1];
-                if (urlParams[idParamName]) {
+                if (showAnnotation == true) {
                     // we have an id param, so make sure the left panel is visible and title is hidden
                     id_parameter = queryParams[idParamName];
-                    showAnnotation = true;
                     document.getElementById('left').style.visibility = "visible";
                     document.getElementById('look-up').style.height = "100%";
                     document.getElementById('anatomyHeading').style.display = "none";
                 } else {
                     // no id so change the UX to hide the left panel
-                    id_parameter = ''
-                    showAnnotation = false;
+                    id_parameter = '';
                     document.getElementById('look-up').style.height = "0";
                     $("#right").css('margin-left', '10px');
                     $(".tree-panel").css('width', '99.5%');
@@ -245,6 +243,14 @@
                 // determine if a parent app exists and change state of treeview to accomodate for it
                 var appName = urlParams["Parent_App"] || null;
                 parentAppExists = appName !== null;
+
+
+                // Show the navbar if static and not embedded in boolean search
+                if ((!showAnnotation && !parentAppExists) || urlParams.showNavbar == "true") {
+                    // property has to be "unset" (which stores a value) rather than trying to apply .css("display, "")
+                    // applying .css("display", "") actually removes the property definition and then the property defined in the CSS document is applied
+                    $("navbar")[0].style.display = "unset";
+                }
 
                 // make sure search div, expand/collapse, and load icon are visible
                 // hide load icon later when data comes back

--- a/treeview/themes/default/images/style.css
+++ b/treeview/themes/default/images/style.css
@@ -1,5 +1,10 @@
 /* jsTree default theme */
 
+/* hide navbar by default on page load */
+navbar {
+    display: none;
+}
+
 #left {
   visibility: hidden;
   padding-right: 0px;


### PR DESCRIPTION
Opening this PR so the changes can be reviewed before merging them.

navbar shows properly when looking at static treeview:
[../deriva-webapps/treeview/](https://dev.rebuildingakidney.org/~jchudy/deriva-webapps/treeview/)

navbar hides properly when looking at static treeview with a query param:
[../deriva-webapps/treeview/?Navbar=false](https://dev.rebuildingakidney.org/~jchudy/deriva-webapps/treeview/?Navbar=false)

navbar hides properly when looking at dynamic treeview:
[../deriva-webapps/treeview/?Specimen_RID=N-GXNY](https://dev.rebuildingakidney.org/~jchudy/deriva-webapps/treeview/?Specimen_RID=N-GXNY)

navbar shows properly when looking at dynamic treeview with a query param:
[../deriva-webapps/treeview/?Specimen_RID=N-GXNY&Navbar=true](https://dev.rebuildingakidney.org/~jchudy/deriva-webapps/treeview/?Specimen_RID=N-GXNY&Navbar=true)

navbar hides properly when treeview is in an iframe:
[../deriva-webapps/boolean-search/](https://dev.rebuildingakidney.org/~jchudy/deriva-webapps/boolean-search/)