### PR TITLE
Enable treeview background in print mode and persist scrolling

### DIFF
--- a/treeview/index.html
+++ b/treeview/index.html
@@ -6,7 +6,7 @@
     <!-- issue with using out own jquery-ui css is that it will be missing icons/images that have a relative path on jquery website -->
     <!-- <link rel="stylesheet" href="resources/styles/jquery-ui.css"> -->
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
-    <script src="../../chaise/scripts/vendor/jquery-3.3.1.min.js"></script>
+    <script src="../../chaise/scripts/vendor/jquery-3.4.1.min.js"></script>
     <script src="util/jquery-ui.js"></script>
     <script src="util/jstree.js"></script>
     <script src="util/jstreegrid.js"></script>

--- a/treeview/themes/default/images/style.css
+++ b/treeview/themes/default/images/style.css
@@ -1995,3 +1995,36 @@ input {
 }
 
 /* IE6 END */
+
+/* PRINT MEDIA STYLES AND RULES */
+@media print {
+  a[href]:after {
+    content: none !important;
+  }
+
+  html{
+    overflow: scroll !important;
+  }
+
+  .jstree-default .jstree-leaf>.jstree-ocl{
+     background-position: -66px -4px !important;
+     background-image: url(32px.png) !important;
+  }
+
+  .jstree-default .jstree-closed>.jstree-ocl{
+    background-position: -98px -4px !important;
+    background-image: url(32px.png) !important;
+    background-color: transparent !important;
+  }
+
+  .jstree-default .jstree-node{
+    background-position: -290px -4px !important;
+    background-image: url(32px.png) !important;
+    background-repeat: repeat-y !important;
+  }
+
+  .jstree-default .jstree-open>.jstree-ocl {
+    background-position: -130px -4px !important;
+    background-image: url(32px.png) !important;
+  }
+}


### PR DESCRIPTION
This PR includes the following fixes

- [x] Fixed the print for iframes with Treeview document to show the tree hierarchy during print.
- [x] Persisted scrolling during print
- [x] Parsing the URL to check if there is an embedded YouTube video. If yes, then add a class to apply the above discussed custom styles.
- [x] The same has been processed for the <video> markdown pattern as well.

- Applying the thumbnail to the YouTube video on print was complicated as the styles are applied via YouTube and we have limited access to it. Hence, the alternative was to display a note informing the user that the video is hidden during print and possibly provide the URL of the hidden video.