### PR TITLE
Rename install to deploy + add a dummy dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 node_modules
 .DS_Store*
 boolean-search/booleansearch-config.js

--- a/Makefile
+++ b/Makefile
@@ -3,68 +3,73 @@ WEBAPPS_REL_PATH?=deriva-webapps/
 
 WEBAPPSDIR:=$(WEB_INSTALL_ROOT)$(WEBAPPS_REL_PATH)
 
+# TODO while we're not doing anything to "build" we should eventually do
+#      so we created this placeholder that in the future will be implemented
+.PHONY: dist
+dist: ;
+
 #exclude <app>-config.js to not override one on deployment
-.PHONY: install
-install: dont_install_in_root print-variables install-boolean-search install-heatmap install-lineplot install-plot install-treeview
+.PHONY: deploy
+deploy: dont_deploy_in_root print-variables deploy-boolean-search deploy-heatmap deploy-lineplot deploy-plot deploy-treeview
 
-.PHONY: install-w-config
-install-w-config:dont_install_in_root print-variables install-boolean-search-w-config install-heatmap-w-config install-lineplot-w-config install-plot-w-config install-treeview-w-config
+.PHONY: deploy-w-config
+deploy-w-config:dont_deploy_in_root print-variables deploy-boolean-search-w-config deploy-heatmap-w-config deploy-lineplot-w-config deploy-plot-w-config deploy-treeview-w-config
 
-.PHONY: install-boolean-search
-install-boolean-search: dont_install_in_root print-variables
+.PHONY: deploy-boolean-search
+deploy-boolean-search: dont_deploy_in_root print-variables
 	$(info - deploying boolean-search)
 	@rsync -avz --exclude='/boolean-search/booleansearch-config*' boolean-search $(WEBAPPSDIR)
 
-.PHONY: install-boolean-search-w-config
-install-boolean-search-w-config: dont_install_in_root print-variables
+.PHONY: deploy-boolean-search-w-config
+deploy-boolean-search-w-config: dont_deploy_in_root print-variables
 	$(info - deploying boolean-search with the existing config file(s))
 	@rsync -avz boolean-search $(WEBAPPSDIR)
 
-.PHONY: install-heatmap
-install-heatmap: dont_install_in_root print-variables
+.PHONY: deploy-heatmap
+deploy-heatmap: dont_deploy_in_root print-variables
 	$(info - deploying heatmap)
 	@rsync -avz --exclude='/heatmap/heatmap-config*' heatmap $(WEBAPPSDIR)
 
-.PHONY: install-heatmap-w-config
-install-heatmap-w-config: dont_install_in_root print-variables
+.PHONY: deploy-heatmap-w-config
+deploy-heatmap-w-config: dont_deploy_in_root print-variables
 	$(info - deploying heatmap with the existing config file(s))
 	@rsync -avz heatmap $(WEBAPPSDIR)
 
-.PHONY: install-lineplot
-install-lineplot: dont_install_in_root print-variables
+.PHONY: deploy-lineplot
+deploy-lineplot: dont_deploy_in_root print-variables
 	$(info - deploying lineplot)
 	@rsync -avz --exclude='/lineplot/lineplot-config*' lineplot $(WEBAPPSDIR)
 
-.PHONY: install-lineplot-w-config
-install-lineplot-w-config: dont_install_in_root print-variables
+.PHONY: deploy-lineplot-w-config
+deploy-lineplot-w-config: dont_deploy_in_root print-variables
 	$(info - deploying lineplot with the existing config file(s))
 	@rsync -avz lineplot $(WEBAPPSDIR)
 
-.PHONY: install-plot
-install-plot: dont_install_in_root print-variables
+.PHONY: deploy-plot
+deploy-plot: dont_deploy_in_root print-variables
 	$(info - deploying plot)
 	@rsync -avz --exclude='/plot/plot-config*' plot $(WEBAPPSDIR)
 
-.PHONY: install-plot-w-config
-install-plot-w-config: dont_install_in_root print-variables
+.PHONY: deploy-plot-w-config
+deploy-plot-w-config: dont_deploy_in_root print-variables
 	$(info - deploying plot with the existing config file(s))
 	@rsync -avz plot $(WEBAPPSDIR)
 
-.PHONY: install-treeview
-install-treeview: dont_install_in_root print-variables
+.PHONY: deploy-treeview
+deploy-treeview: dont_deploy_in_root print-variables
 	$(info - deploying treeview)
 	@rsync -avz --exclude='/treeview/treeview-config*' treeview $(WEBAPPSDIR)
 
-.PHONY: install-treeview-w-config
-install-treeview-w-config: dont_install_in_root print-variables
+.PHONY: deploy-treeview-w-config
+deploy-treeview-w-config: dont_deploy_in_root print-variables
 	$(info - deploying treeview with the existing config file(s))
 	@rsync -avz treeview $(WEBAPPSDIR)
 
-dont_install_in_root:
+dont_deploy_in_root:
 	@echo "$(WEBAPPSDIR)" | egrep -vq "^/$$|.*:/$$"
 
 print-variables:
-	$(info building and deploying to: $(WEBAPPSDIR))
+	$(info deploying to: $(WEBAPPSDIR))
 
 #Rules for help/usage
 .PHONY: help usage
@@ -72,15 +77,15 @@ help: usage
 usage:
 	@echo "Usage: make [target]"
 	@echo "Available targets:"
-	@echo "  install                           install all the apps"
-	@echo "  install-w-config                  install all the apps with the existing configs"
-	@echo "  install-boolean-search            install boolean search app"
-	@echo "  install-boolean-search-w-config   install boolean search app with the existing config file(s)"
-	@echo "  install-heatmap                   install heatmap app"
-	@echo "  install-heatmap-w-config          install heatmap app with the existing config file(s)"
-	@echo "  install-lineplot                  install lineplot app"
-	@echo "  install-lineplot-w-config         install lineplot app with the existing config file(s)"
-	@echo "  install-plot                      install plot app"
-	@echo "  install-plot-w-config             install plot with the existing config file(s)"
-	@echo "  install-treeview                  install treeview app"
-	@echo "  install-treeview-w-config         install treeview app with the existing config file(s)"
+	@echo "  deploy                           deploy all the apps"
+	@echo "  deploy-w-config                  deploy all the apps with the existing configs"
+	@echo "  deploy-boolean-search            deploy boolean search app"
+	@echo "  deploy-boolean-search-w-config   deploy boolean search app with the existing config file(s)"
+	@echo "  deploy-heatmap                   deploy heatmap app"
+	@echo "  deploy-heatmap-w-config          deploy heatmap app with the existing config file(s)"
+	@echo "  deploy-lineplot                  deploy lineplot app"
+	@echo "  deploy-lineplot-w-config         deploy lineplot app with the existing config file(s)"
+	@echo "  deploy-plot                      deploy plot app"
+	@echo "  deploy-plot-w-config             deploy plot with the existing config file(s)"
+	@echo "  deploy-treeview                  deploy treeview app"
+	@echo "  deploy-treeview-w-config         deploy treeview app with the existing config file(s)"

--- a/boolean-search/booleansearch-config-sample.js
+++ b/boolean-search/booleansearch-config-sample.js
@@ -1,6 +1,6 @@
 /**
  * Please Note
- * This is a sample configuration file. Copy the contents to `booleansearch-config.js` and run `make install_w_configs` to use this configuration
+ * This is a sample configuration file.
  */
 var booleanSearchConfig = {
     data: {

--- a/docs/dev-docs/setup-apps.md
+++ b/docs/dev-docs/setup-apps.md
@@ -2,7 +2,7 @@
 
 ### Installation
 
-To install each webapp follow the information in the readme [found here](https://github.com/informatics-isi-edu/deriva-webapps/#installation).
+To install each webapp follow the information in the readme [found here](../user-docs/installation.md).
 
 #### App configuration
 

--- a/docs/user-docs/installation.md
+++ b/docs/user-docs/installation.md
@@ -11,7 +11,7 @@ The current implementation of each app makes different assumption about the loca
 
 ## Deploying
 
-1. First you need to setup some environment variables to tell Chaise where it should install the package. The following are the variables and their default values:
+1. First you need to setup some environment variables to tell Chaise where it should deploy the package. The following are the variables and their default values:
 
     ```
     WEB_INSTALL_ROOT=/var/www/html/
@@ -22,29 +22,29 @@ The current implementation of each app makes different assumption about the loca
     Notes:
       - All the variables MUST have a trailing `/`.
 
-      - If you're installing remotely, since we're using this location in `rsync` command, you can use a remote location `username@host:public_html/deriva-webapps` for this variable.
+      - If you're deploying remotely, since we're using this location in `rsync` command, you can use a remote location `username@host:public_html/deriva-webapps` for this variable.
 
-2. After making sure the variable is propertly set, you can run the install commands. To install all the deriva web apps you can use the `install` target:
+2. After making sure the variable is propertly set, you can run the deploy commands. To deploy all the deriva web apps you can use the `deploy` target:
 
     ```
-    $ make install
+    $ make deploy
     ```
 
     Notes:
-      - The following are alternative make targets that can be used for installation:
-        - `install-w-config`: The same as `install` and will aslo copy all the configuration files.
-        - `install-boolean-search`: Only install boolean-search.
-        - `install-boolean-search-w-config`: Only install boolean-search and copy its configuration files.
-        - `install-heatmap`: Only install boolean-search and copy its configuration files.
-        - `install-heatmap-w-config`: Only install boolean-search and copy its configuration files.
-        - `install-lineplot`: Only install lineplot and copy its configuration files.
-        - `install-lineplot-w-config`: Only install lineplot and copy its configuration files.
-        - `install-plot`: Only install plot and copy its configuration files.
-        - `install-plot-w-config`: Only install plot and copy its configuration files.
-        - `install-treeview`: Only install treeview and copy its configuration files.
-        - `install-treeview-w-config`: Only install treeview and copy its configuration files.
+      - The following are alternative make targets that can be used for deployment:
+        - `deploy-w-config`: The same as `deploy` and will aslo copy all the configuration files.
+        - `deploy-boolean-search`: Only deploy boolean-search.
+        - `deploy-boolean-search-w-config`: Only deploy boolean-search and copy its configuration files.
+        - `deploy-heatmap`: Only deploy boolean-search and copy its configuration files.
+        - `deploy-heatmap-w-config`: Only deploy boolean-search and copy its configuration files.
+        - `deploy-lineplot`: Only deploy lineplot and copy its configuration files.
+        - `deploy-lineplot-w-config`: Only deploy lineplot and copy its configuration files.
+        - `deploy-plot`: Only deploy plot and copy its configuration files.
+        - `deploy-plot-w-config`: Only deploy plot and copy its configuration files.
+        - `deploy-treeview`: Only deploy treeview and copy its configuration files.
+        - `deploy-treeview-w-config`: Only deploy treeview and copy its configuration files.
 
-      - If the given directory does not exist, it will first create it. So you may need to run `make install` with _super user_ privileges depending on the installation directory you choose.
+      - If the given directory does not exist, it will first create it. So you may need to run `make deploy` with _super user_ privileges depending on the deployment directory you choose.
 
 
 ## Running

--- a/heatmap/README.md
+++ b/heatmap/README.md
@@ -56,5 +56,4 @@ if (typeof module === 'object' && module.exports && typeof require === 'function
 ```
 ## Installation
 
-### Installation Path
-Change the installation path by changing the value of INSDIR in Makefile and then execute the "make install" command.
+Refer to [installation guide](../docs/user-docs/installation.md).

--- a/heatmap/heatmap-config-sample.js
+++ b/heatmap/heatmap-config-sample.js
@@ -1,6 +1,6 @@
 /**
  * Please Note
- * This is a sample configuration file. Copy the contents to `heatmap-config.js` and run `make install_w_configs` to use this configuration
+ * This is a sample configuration file.
  */
 
 var heatmapConfig = {

--- a/lineplot/lineplot-config-sample.js
+++ b/lineplot/lineplot-config-sample.js
@@ -1,6 +1,6 @@
 /**
  * Please Note
- * This is a sample configuration file. Copy the contents to `lineplot-config.js` and run `make install_w_configs` to use this configuration
+ * This is a sample configuration file.
  */
 
 var currentDate = Date.now();

--- a/plot/README.md
+++ b/plot/README.md
@@ -128,5 +128,4 @@ The file [plot-config-sample.js](plot-config-sample.js) contains examples for di
 
 ## Installation
 
-### Installation Path
-Change the installation path by changing the value of INSDIR in Makefile and then execute the `make install` command.
+Refer to [installation guide](../docs/user-docs/installation.md).

--- a/plot/plot-config-sample.js
+++ b/plot/plot-config-sample.js
@@ -1,6 +1,6 @@
 /**
  * Please Note
- * This is a sample configuration file. Copy the contents to `plot-config.js` and run `make install_w_configs` to use this configuration
+ * This is a sample configuration file.
  * Even more examples can be found in division repo recipes for rbk dev/staging/production
  */
  var plotConfigs = {

--- a/treeview/treeview-config-sample.js
+++ b/treeview/treeview-config-sample.js
@@ -1,6 +1,6 @@
 /**
  * Please Note
- * This is a sample configuration file. Copy the contents to `treeview-config.js` and run `make install_w_configs` to use this configuration
+ * This is a sample configuration file.
  */
 
 // url paramters (accessed by $url_parameters)


### PR DESCRIPTION
For more information please refer to [this PR in chaise](https://github.com/informatics-isi-edu/chaise/pull/2181).

The only extra change here is the dummy `dist` target. While we're not doing any "build" here, but eventually (in `react` branch) we will have this. To make the future changes in recipes simpler, we decided to add this dummy target for now that doesn't do anything.