### PR TITLE
fixed a bug for search function in matrix app

### DIFF
--- a/src/components/matrix/virtualized-grid.tsx
+++ b/src/components/matrix/virtualized-grid.tsx
@@ -97,7 +97,7 @@ const VirtualizedGrid = (
       const offset = index * cellHeight - gridHeight / 2 - cellHeight / 2;
       rowLabelRef?.current?.scrollTo(offset);
       gridRef?.current?.scrollTo({ scrollTop: offset });
-
+      setScrollY(offset);
       setSearchedRowIndex(index);
       setSearchedColIndex(null);
     },
@@ -106,7 +106,7 @@ const VirtualizedGrid = (
       const offset = index * cellWidth - gridWidth / 2 - cellWidth / 2;
       columnLabelRef.current.scrollTo(offset);
       gridRef.current.scrollTo({ scrollLeft: offset });
-
+      setScrollX(offset);
       setSearchedRowIndex(null);
       setSearchedColIndex(index);
     },


### PR DESCRIPTION
This PR fixes a bug that may happen when the user searches for an item after initially opening the matrix app.

**Bug Description:**
When we initially open the matrix app and search for an item, which is located to the right of the column header, the column header and grid are correctly positioned to correspond with the search. However, a problem arises when we move the mouse over the row header and then scroll vertically. In this scenario, the grid and column header revert to the leftmost position, which is not the intended behavior. This problem also arises when we search for an item in the row header and scroll the column header.

**Expected Behavior:**
Upon performing a search and subsequently scrolling vertically, the column header and grid should maintain their correct positioning, regardless of the mouse interaction with the row header. Same as searching a row item and scrolling horizontally.

**This pull request introduces the following changes:**
In `virtualized-grid.tsx`, added setScrollY for the searchRow function and setScrollX for the searchCol function.