### PR TITLE
Removing the calculated height to take the available height

### DIFF
--- a/src/hooks/chart.ts
+++ b/src/hooks/chart.ts
@@ -752,13 +752,10 @@ export const useChartData = (plot: Plot) => {
       result.layout.modebar = { remove: plot?.plotly?.config?.modeBarButtonsToRemove };
     }
     if (plot.plot_type === 'heatmap') {
-      result.layout.margin = additionalLayout.margin;
-      // result.layout.height = '100%';
-      result.layout.width = additionalLayout.width;
       if (result.data[0]) {
         result.data[0]['colorbar'] = {
           lenmode: 'pixels',
-          len: additionalLayout.height - 40 < 100 ? additionalLayout.height - 40 : 100
+          len: 100
         }
       }
     }
@@ -789,14 +786,15 @@ export const useChartData = (plot: Plot) => {
   }
 
   /**
+   * Calculates the height and margins of the heatmap based on the number of y values and length of the longest X label
+   * so that the labels do not get clipped and the bar height is adjusted accordingly.
    * 
    * @param input : Input parameters of heatmap directive
    * @param longestXTick : Length of longest X axis label
    * @param longestYTick : Length of longest Y axis label
    * @param lengthY : Number of Y values
    * @returns 
-   * Calculates the height and margins of the heatmap based on the number of y values and length of the longest X label
-   * so that the labels do not get clipped and the bar height is adjusted accordingly.
+   
    * Return an object with all the required layout parameters.
    * @example
    * {

--- a/src/hooks/chart.ts
+++ b/src/hooks/chart.ts
@@ -753,7 +753,7 @@ export const useChartData = (plot: Plot) => {
     }
     if (plot.plot_type === 'heatmap') {
       result.layout.margin = additionalLayout.margin;
-      result.layout.height = additionalLayout.height;
+      // result.layout.height = '100%';
       result.layout.width = additionalLayout.width;
       if (result.data[0]) {
         result.data[0]['colorbar'] = {

--- a/src/hooks/chart.ts
+++ b/src/hooks/chart.ts
@@ -793,9 +793,7 @@ export const useChartData = (plot: Plot) => {
    * @param longestXTick : Length of longest X axis label
    * @param longestYTick : Length of longest Y axis label
    * @param lengthY : Number of Y values
-   * @returns 
-   
-   * Return an object with all the required layout parameters.
+   * @returns an object with all the required layout parameters.
    * @example
    * {
    * 	height: height of the heatmap,


### PR DESCRIPTION
Heatmap plot in the 'Cell Viability' section on this page was not taking the full height so to fix that and use the available height for heatmap in plot app, these changes are made. https://smite-dev.eitm.org/chaise/record/#1/Sample:Sample_Batch/RID=8Y0