### PR TITLE
Matrix App: Legend

### DIFF
--- a/config/matrix-config-sample.js
+++ b/config/matrix-config-sample.js
@@ -1,4 +1,12 @@
 /**
+ * Please refer to the following for document for more information:
+ * https://github.com/informatics-isi-edu/deriva-webapps/blob/master/docs/user-docs/matrix-app.md#overal-structure
+ *
+ * You can also find the TypeScript definitions here:
+ * https://github.com/informatics-isi-edu/deriva-webapps/blob/master/src/models/matrix-config.ts
+ */
+
+/**
  * The base URI for the data API endpoint
  */
 var baseUri =
@@ -11,17 +19,9 @@ var matrixConfigs = {
      */
     xURL: baseUri + '/sort_key:=X:sort_key,id:=X:id,title:=X:name@sort(sort_key)',
     /**
-     * API for the tree data of the x axis (must return child_id and parent_id. other columns will be ignored.)
-     */
-    xTreeURL: baseUri + 'x_values_tree.json',
-    /**
      * API for the y axis data (must return id and title. other projected columns will be ignored.)
      */
     yURL: baseUri + '/id:=Y:id,title:=Y:name@sort(title)',
-    /**
-     * API for the tree data of the y axis (must return child_id and parent_id. other columns will be ignored.)
-     */
-    yTreeURL: baseUri + 'y_values_tree.json',
     /**
      * API for the z axis data (color axis) (must return id and title. other projected columns will be ignored.)
      */
@@ -98,15 +98,7 @@ var matrixConfigs = {
         /**
          * Width of the row headers
          */
-        width: 250,
-        /**
-         * Whether allow scroll
-         */
-        // scrollable: true,
-        /**
-         * The max width of the scrollable content
-         */
-        // scrollableMaxWidth: 400,
+        width: 250
       },
       /**
        * Properties of the column headers
@@ -115,15 +107,7 @@ var matrixConfigs = {
         /**
          * Height of the column headers
          */
-        height: 80,
-        /**
-         * Whether allow scroll
-         */
-        // scrollable: true,
-        /**
-         * The max height of the scrollable content
-         */
-        // scrollableMaxHeight: 120,
+        height: 80
       },
       /**
        * Properties of the legend

--- a/config/matrix-config-sample.js
+++ b/config/matrix-config-sample.js
@@ -11,9 +11,17 @@ var matrixConfigs = {
      */
     xURL: baseUri + '/sort_key:=X:sort_key,id:=X:id,title:=X:name@sort(sort_key)',
     /**
+     * API for the tree data of the x axis (must return child_id and parent_id. other columns will be ignored.)
+     */
+    xTreeURL: baseUri + 'x_values_tree.json',
+    /**
      * API for the y axis data (must return id and title. other projected columns will be ignored.)
      */
     yURL: baseUri + '/id:=Y:id,title:=Y:name@sort(title)',
+    /**
+     * API for the tree data of the y axis (must return child_id and parent_id. other columns will be ignored.)
+     */
+    yTreeURL: baseUri + 'y_values_tree.json',
     /**
      * API for the z axis data (color axis) (must return id and title. other projected columns will be ignored.)
      */
@@ -87,26 +95,57 @@ var matrixConfigs = {
        * Properties of the row headers
        */
       rowHeader: {
-        width: 250
+        /**
+         * Width of the row headers
+         */
+        width: 250,
+        /**
+         * Whether allow scroll
+         */
+        // scrollable: true,
+        /**
+         * The max width of the scrollable content
+         */
+        // scrollableMaxWidth: 400,
       },
       /**
        * Properties of the column headers
        */
       columnHeader: {
-        height: 80
+        /**
+         * Height of the column headers
+         */
+        height: 80,
+        /**
+         * Whether allow scroll
+         */
+        // scrollable: true,
+        /**
+         * The max height of the scrollable content
+         */
+        // scrollableMaxHeight: 120,
       },
       /**
-       * Height of the legend
+       * Properties of the legend
        */
-      legendHeight: 200,
-      /**
-       * Width of the legend bar
-       */
-      legendBarWidth: 55,
-      /**
-       * Height of the legend bar
-       */
-      legendBarHeight: 15,
+      legend: {
+        /**
+         * Height of the legend
+         */
+        height: 100,
+        /**
+         * Width of the legend bar
+         */
+        barWidth: 55,
+        /**
+         * Height of the legend bar
+         */
+        barHeight: 15,
+        /**
+         * Max number of lines showing the legend content
+         */
+        lineClamp: 2,
+      }
     },
   },
 };

--- a/src/assets/scss/_matrix.scss
+++ b/src/assets/scss/_matrix.scss
@@ -291,7 +291,7 @@ body:not(.chaise-iframe) {
 
   .legend-container {
     flex-direction: column;
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: visible;
     margin-top: 25px;
   }
@@ -304,8 +304,6 @@ body:not(.chaise-iframe) {
   .legend-links-container {
     display: inline-flex;
     flex-direction: row;
-    margin-top: 10px;
-    margin-left: 15px;
   }
 
   .legend-bar {
@@ -314,22 +312,24 @@ body:not(.chaise-iframe) {
   }
 
   .legend-link-div {
+    transform-origin: top left;
     -webkit-transform: translate() rotate(45deg);
     -ms-transform: rotate(45deg);
     transform: rotate(45deg);
   }
 
   .legend-link {
-    white-space: nowrap;
-
     &:hover {
       font-weight: bold;
     }
   }
 
   .split-text {
+    text-overflow: -o-ellipsis-lastline;
     overflow: hidden;
     text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
   }
 
   .color-toggle-container {

--- a/src/components/matrix/legend.tsx
+++ b/src/components/matrix/legend.tsx
@@ -24,6 +24,10 @@ export type LegendProps = {
    */
   barHeight: number;
   /**
+   * Max number of lines showing the legend content
+   */
+  lineClamp: number;
+  /**
    * color scale to use where index corresponds to ordering of scale shown
    */
   colorScale: Array<string>;
@@ -37,12 +41,15 @@ const Legend = ({
   height,
   barWidth,
   barHeight,
+  lineClamp,
   data,
   colorScale,
 }: LegendProps): JSX.Element => {
   const legendStyles: CSSProperties = {
     height: height,
     width: width,
+    display: 'flex',
+    alignItems: 'flex-start',
   };
 
   return (
@@ -59,12 +66,14 @@ const Legend = ({
           />
         ))}
       </div>
-      <div className='legend-links-container'>
+      {/* Use marginLeft to keep each legend text be at the middle of the legend bar */}
+      <div className='legend-links-container' style={{marginLeft: barWidth / 2}}>
         {data.map((legendData, index) => (
           <MemoizedLegendHeader
             key={legendData.title}
             index={index}
             width={barWidth}
+            lineClamp={lineClamp}
             legendHeight={height}
             data={data}
           />
@@ -103,18 +112,24 @@ type LegendHeaderProps = {
   data: Array<LegendDatum>;
   legendHeight: number;
   width: number;
+  lineClamp: number;
 };
 
 /**
  * Each header of the Legend
  */
-const LegendHeader = ({ index, legendHeight, data, width }: LegendHeaderProps) => {
+const LegendHeader = ({ index, legendHeight, data, width, lineClamp }: LegendHeaderProps) => {
   const { link, title } = data[index];
+
+  const splitTextStyle = {
+    width: legendHeight - 25,
+    WebkitLineClamp: lineClamp, // Number of lines to show
+  };
 
   return (
     <div className='legend-link-div' style={{ width: width }}>
       <a className='legend-link' href={link} title={title}>
-        <div className='split-text' style={{ width: legendHeight - 25 }}>
+        <div className='split-text' style={splitTextStyle}>
           {title}
         </div>
       </a>

--- a/src/models/matrix-config.ts
+++ b/src/models/matrix-config.ts
@@ -105,17 +105,9 @@ export type MatrixStyles = {
    */
   columnHeader?: ColHeaderStyles;
   /**
-   * Height of the legend
+   * Properties of the legend component
    */
-  legendHeight?: number;
-  /**
-   * Width of the legend bar
-   */
-  legendBarWidth?: number;
-  /**
-   * Height of the legend bar
-   */
-  legendBarHeight?: number;
+  legend?: LegendStyles;
 };
 
 export type RowHeaderStyles = {
@@ -146,6 +138,25 @@ export type ColHeaderStyles = {
    * The max height of the scrollable content
    */
   scrollableMaxHeight?: number;
+};
+
+export type LegendStyles = {
+  /**
+   * Height of the legend
+   */
+  height?: number;
+  /**
+   * Width of the legend bar
+   */
+  barWidth?: number;
+  /**
+   * Height of the legend bar
+   */
+  barHeight?: number;
+  /**
+   * Max number of lines showing the legend content
+   */
+  lineClamp?: number;
 };
 
 export type MatrixConfig = {

--- a/src/pages/matrix.tsx
+++ b/src/pages/matrix.tsx
@@ -169,18 +169,17 @@ const MatrixApp = (): JSX.Element => {
   const cellHeight = styles?.cellHeight ? styles?.cellHeight : 25;
   const cellWidth = styles?.cellWidth ? styles?.cellWidth : 25;
 
-  let legendHeight = styles?.legend?.height ? styles?.legend.height : 200;
+  const legendHeight = styles?.legend?.height ? styles?.legend.height : 200;
 
   const widthBufferSpace = 50; // buffer space for keeping everything in viewport
-  const heightBufferSpace = legendHeight; // buffer space for keeping everything in viewport
+  const heightBufferSpace = legendHeight * 2; // buffer space for keeping everything in viewport
 
   const strictMinHeight = 200;
   const strictMinWidth = 400;
 
   let gridHeight = Math.min(
     cellHeight * numRows, // can't exceed total grid
-    // 250 = 50 (navbar) + 20 (matrix-page: padding) + 100 (title-container) + 30 (options-container)
-    height - 250 - colHeaderHeight - heightBufferSpace // can't exceed browser height
+    height - colHeaderHeight - heightBufferSpace // can't exceed browser height
   );
   if (maxRows) {
     // restrict by maxRows if exists
@@ -188,9 +187,6 @@ const MatrixApp = (): JSX.Element => {
   }
   gridHeight = Math.max(gridHeight, strictMinHeight);
 
-  // similar to gridHeight, legendHeight also need to dynamically change as the height of grid and viewport change
-  // 250 = 50 (navbar) + 20 (matrix-page: padding) + 100 (title-container) + 30 (options-container)
-  legendHeight = Math.min(legendHeight, height - 250 - gridHeight - colHeaderHeight);
   let gridWidth = Math.min(
     cellWidth * numColumns, // can't exceed total grid
     width - rowHeaderWidth - widthBufferSpace // can't exceed browser width


### PR DESCRIPTION
The latest commit focuses on the following issues:

### Legend improvements
- Showing ellipsis or multiple lines for legend labels: Use webkit-line-clamp in CSS to set max lines showing to solve the issue.
  - Modified `src/models/matrix-config.ts` to merge all attributes of Legend to `LegendStyles` and add one more attribute for lineClamp.
  - Modified `src/pages/matrix.tsx` to process default number and pass lineClamp attribute to `Legend` component.
  - Modified `src/components/matrix/legend.tsx` to receive lineClamp attribute and set it as style of `split-text`.
- Make sure the height logic of the grid and legend work properly: Adjust the height of Legend component dynamically.
  - Modified `src/pages/matrix.tsx` to add logic to calculate the height of Legend component to enable the scrollbar of it always shows within the viewport. This is similar to what we did for `gridHeight`.
- Make sure the legend is always horizontally center aligned: Adjust the width of Legend component dynamically.
  - Modified `src/pages/matrix.tsx` to add logic to calculate the width of Legend component with comparison among its children elements and the sum of gridWidth + rowHeaderWidth.
  - Modified `src/assets/scss/_matrix.scss` to set text rotate origin as top left, so that improve the UI clarity and calculation accuracy.
  - Modified `src/components/matrix/legend.tsx` to use `flex` display and `flex-start` alignItems to align bars and texts to avoid aliasing. Modified the style of `legend-links-container` to `marginLeft: barWidth / 2` to align each text as the center of each bar.
- Don't show the hr scrollbar if the legend doesn't need a scroll.
  - Modified `src/assets/scss/_matrix.scss` to add `overflow-x: auto` to the `legend-container` class.