### PR TITLE
Update dependencies

### DIFF
--- a/config/treeview-config-sample.js
+++ b/config/treeview-config-sample.js
@@ -1,84 +1,78 @@
-/**
- * Please Note
- * This is a sample configuration file.
- */
-
 // url paramters (accessed by $url_parameters)
 // - Species
 // - Specimen_RID
 
 // query patterns will be appended to the relative path of the current server (ie. "https://dev.rebuildingakidney.org")
 // patterns can have markdown in it that will be rendered using handlebars
-var treeviewConfigs = {
-  '*': {
-    title_markdown_pattern: "{{$url_parameters.Species}} Anatomy Tree",
-    // user-input/filter configuration
-    filters: [
+var treeviewConfig = {
+  title_markdown_pattern: "{{$url_parameters.Species}} Anatomy Tree",
+  // user-input/filter configuration
+  filters: [
       //species
       {
-        filter_column_name: "Name", // column value stored for filter info in $filters[0], should match a column name in the projections list
-        display_mode: "drop-down", // or false (not show)
-        display_text: "{{{Name}}}",
-        query_pattern: "/ermrest/catalog/2/attributegroup/M:=Vocabulary:Species/id:=M:Name,M:ID,M:Name@sort(Name)",
-        schema_table: "Vocabulary:Species", // for logging purposes
-        default_id: 'Mus musculus', // note: might not be required?
-        selected_filter: {
-          required_url_parameters: ["Species"], // if url param is present, false or null if not
-          default: 'Mus musculus',
-          selected_id: "{{{$url_parameters.Species}}}",
-          if_empty_id: false // if the selected_id is not in the list (e.g. null/empty array/1+), use this stage.. If this is not defined or false, just throw an error
-        }
+          filter_column_name: "Name", // column value stored for filter info in $filters[0], should match a column name in the projections list
+          display_mode: "drop-down", // or false (not show)
+          display_text: "{{{Name}}}",
+          query_pattern: "/ermrest/catalog/2/attributegroup/M:=Vocabulary:Species/id:=M:Name,M:ID,M:Name@sort(Name)",
+          schema_table: "Vocabulary:Species", // for logging purposes
+          default_id: 'Mus musculus', // note: might not be required?
+          selected_filter: {
+              required_url_parameters: ["Species"], // if url param is present, false or null if not
+              default: 'Mus musculus',
+              selected_id: "{{{$url_parameters.Species}}}",
+              if_empty_id: false // if the selected_id is not in the list (e.g. null/empty array/1+), use this stage.. If this is not defined or false, just throw an error
+          }
       },
       // stage
       {
-        filter_column_name: "Ordinal", // column value stored for filter info in $filters["Ordinal"]
-        display_mode: "drop-down",
-        display_text: "{{{Name}}}{{#if Approximate_Equivalent_Age}}: {{Approximate_Equivalent_Age}}{{/if}}",
-        query_pattern: "/ermrest/catalog/2/attributegroup/M:=Vocabulary:Developmental_Stage/species:=(Species)=(Vocabulary:Species:ID)/Name={{{$url_parameters.Species}}}/$M/id:=M:Name,Ordinal,Name,Approximate_Equivalent_Age@sort(Ordinal)",
-        schema_table: "Vocabulary:Developmental_Stage", // for logging purposes
-        default_id: null,
-        // id_filter_regexp: "TS*", // regular expression for filtering the set of data that is returned from query_pattern
-        // pre-selected through url parameter: either run the query to get the same row or choose existing value
-        selected_filter: {
-          required_url_parameters: ["Specimen_RID"],
-          default: '23',
-          selected_query_pattern: "/ermrest/catalog/2/attributegroup/M:=Gene_Expression:Specimen/RID={{{$url_parameters.Specimen_RID}}}/stage:=left(Stage_ID)=(Vocabulary:Developmental_Stage:ID)/id:=stage:Name,stage:Name,stage:Ordinal,stage:Approximate_Equivalent_Age,Species:=M:Species",
-          selected_id: "{{{$url_parameters.Specimen_RID}}}", // either query_pattern or selected_id for specific value
-          if_empty_id: "All_Stages" // if the selected_id is not in the list (e.g. null/empty array/1+), use this stage.. If this is not defined, just throw an error
-        },
+          filter_column_name: "Ordinal", // column value stored for filter info in $filters["Ordinal"]
+          display_mode: "drop-down",
+          display_text: "{{{Name}}}{{#if Approximate_Equivalent_Age}}: {{Approximate_Equivalent_Age}}{{/if}}",
+          query_pattern: "/ermrest/catalog/2/attributegroup/M:=Vocabulary:Developmental_Stage/species:=(Species)=(Vocabulary:Species:ID)/Name={{{$url_parameters.Species}}}/$M/id:=M:Name,Ordinal,Name,Approximate_Equivalent_Age@sort(Ordinal)",
+          schema_table: "Vocabulary:Developmental_Stage", // for logging purposes
+          default_id: null,
+          // id_filter_regexp: "TS*", // regular expression for filtering the set of data that is returned from query_pattern
+          // pre-selected through url parameter: either run the query to get the same row or choose existing value
+          selected_filter: {
+              required_url_parameters: ["Specimen_RID"],
+              default: '23',
+              selected_query_pattern: "/ermrest/catalog/2/attributegroup/M:=Gene_Expression:Specimen/RID={{{$url_parameters.Specimen_RID}}}/stage:=left(Stage_ID)=(Vocabulary:Developmental_Stage:ID)/id:=stage:Name,stage:Name,stage:Ordinal,stage:Approximate_Equivalent_Age,Species:=M:Species",
+              selected_id: "{{{$url_parameters.Specimen_RID}}}", // either query_pattern or selected_id for specific value
+              if_empty_id: "All_Stages" // if the selected_id is not in the list (e.g. null/empty array/1+), use this stage.. If this is not defined, just throw an error
+          },
 
-        // extra-filter option
-        extra_filter_options: [
-          {
-            // define the object required to be a selector option
-            values: {
-              id: 'All_Stages',
-              Name: 'All Stages',
-              Approximate_Equivalent_Age: ''
-            }
-          }
-        ]
+          // extra-filter option
+          extra_filter_options : [
+              {
+                  // define the object required to be a selector option
+                  values: {
+                      id: 'All_Stages',
+                      Name: 'All Stages',
+                      Approximate_Equivalent_Age: ''
+                  }
+              }
+          ]
       }
-    ],
+  ],
 
-    // main tree
-    tree: {
+  // main tree
+  tree: {
       // required in projection list: parent_id, parent_name, child_id, child_name
       queries: [
-        {
-          filter_set: ["*", "All_Stages"],
-          tree_query: "/ermrest/catalog/2/attribute/M:=Vocabulary:Anatomy_Part_Of_Relationship/F1:=left(Subject)=(Vocabulary:Anatomy:ID)/F1I:=left(Schematic)=(Schematics:Schematic:RID)/$M/F2:=left(Object)=(Vocabulary:Anatomy:ID)/F2I:=left(Schematic)=(Schematics:Schematic:RID)/$M/child_id:=M:Subject,parent_id:=M:Object,child:=F1:Name,parent:=F2:Name,child_image:=F1I:Schematic_URL,parent_image:=F2I:Schematic_URL",
-          tree_schema_table: "Vocabulary:Anatomy_Part_Of_Relationship", // for logging purposes
-          isolated_nodes_query: "/ermrest/catalog/2/attribute/t:=Vocabulary:Anatomy/s:=left(ID)=(Vocabulary:Anatomy_Part_Of_Relationship:Subject)/Subject::null::/$t/o:=left(ID)=(Vocabulary:Anatomy_Part_Of_Relationship:Object)/Object::null::/$t/I:=left(Schematic)=(Schematics:Schematic:RID)/$t/id:=t:ID,dbxref:=t:ID,name:=t:Name,image:=I:Schematic_URL",
-          isolated_schema_table: "Vocabulary:Anatomy", // for logging purposes
-        },
-        {
-          filter_set: ["*", "*"],
-          tree_query: "/ermrest/catalog/2/attribute/M:=Vocabulary:Anatomy_Part_Of_Relationship/F1:=(Subject)=(Vocabulary:Anatomy:ID)/Subject_Starts_at_Ordinal:=(Starts_At)=(Vocabulary:Developmental_Stage:Name)/Ordinal::leq::{{{$filters.Ordinal}}}/$F1/Subject_Ends_At_Ordinal:=(Ends_At)=(Vocabulary:Developmental_Stage:Name)/Ordinal::geq::{{{$filters.Ordinal}}}/$M/F2:=(Object)=(Vocabulary:Anatomy:ID)/Object_Starts_at_Ordinal:=(Starts_At)=(Vocabulary:Developmental_Stage:Name)/Ordinal::leq::{{{$filters.Ordinal}}}/$F2/Object_Ends_At_Ordinal:=(Ends_At)=(Vocabulary:Developmental_Stage:Name)/Ordinal::geq::{{{$filters.Ordinal}}}/$F1/F1I:=left(Schematic)=(Schematics:Schematic:RID)/$F2/F2I:=left(Schematic)=(Schematics:Schematic:RID)/$M/child_id:=M:Subject,parent_id:=M:Object,child:=F1:Name,parent:=F2:Name,child_image:=F1I:Schematic_URL,parent_image:=F2I:Schematic_URL",
-          tree_schema_table: "Vocabulary:Anatomy_Part_Of_Relationship", // for logging purposes
-          isolated_nodes_query: "/ermrest/catalog/2/attribute/t:=Vocabulary:Anatomy/start:=(Starts_At)=(Vocabulary:Developmental_Stage:Name)/start:Ordinal::leq::{{{$filters.Ordinal}}}/$t/end:=(Ends_At)=(Vocabulary:Developmental_Stage:Name)/end:Ordinal::geq::{{{$filters.Ordinal}}}/$t/s:=left(ID)=(Vocabulary:Anatomy_Part_Of_Relationship:Subject)/Subject::null::/$t/o:=left(ID)=(Vocabulary:Anatomy_Part_Of_Relationship:Object)/Object::null::/$t/I:=left(Schematic)=(Schematics:Schematic:RID)/$t/id:=t:ID,dbxref:=t:ID,name:=t:Name,t:Starts_At,t:Ends_At,image:=I:Schematic_URL",
-          isolated_schema_table: "Vocabulary:Anatomy", // for logging purposes
-        }
+          {
+              filter_set: ["*", "All_Stages"],
+              tree_query: "/ermrest/catalog/2/attribute/M:=Vocabulary:Anatomy_Part_Of_Relationship/F1:=left(Subject)=(Vocabulary:Anatomy:ID)/F1I:=left(Schematic)=(Schematics:Schematic:RID)/$M/F2:=left(Object)=(Vocabulary:Anatomy:ID)/F2I:=left(Schematic)=(Schematics:Schematic:RID)/$M/child_id:=M:Subject,parent_id:=M:Object,child:=F1:Name,parent:=F2:Name,child_image:=F1I:Schematic_URL,parent_image:=F2I:Schematic_URL",
+              tree_schema_table: "Vocabulary:Anatomy_Part_Of_Relationship", // for logging purposes
+              isolated_nodes_query: "/ermrest/catalog/2/attribute/t:=Vocabulary:Anatomy/s:=left(ID)=(Vocabulary:Anatomy_Part_Of_Relationship:Subject)/Subject::null::/$t/o:=left(ID)=(Vocabulary:Anatomy_Part_Of_Relationship:Object)/Object::null::/$t/I:=left(Schematic)=(Schematics:Schematic:RID)/$t/id:=t:ID,dbxref:=t:ID,name:=t:Name,image:=I:Schematic_URL",
+              isolated_schema_table: "Vocabulary:Anatomy", // for logging purposes
+          },
+          {
+              filter_set: ["*", "*"],
+              tree_query: "/ermrest/catalog/2/attribute/M:=Vocabulary:Anatomy_Part_Of_Relationship/F1:=(Subject)=(Vocabulary:Anatomy:ID)/Subject_Starts_at_Ordinal:=(Starts_At)=(Vocabulary:Developmental_Stage:Name)/Ordinal::leq::{{{$filters.Ordinal}}}/$F1/Subject_Ends_At_Ordinal:=(Ends_At)=(Vocabulary:Developmental_Stage:Name)/Ordinal::geq::{{{$filters.Ordinal}}}/$M/F2:=(Object)=(Vocabulary:Anatomy:ID)/Object_Starts_at_Ordinal:=(Starts_At)=(Vocabulary:Developmental_Stage:Name)/Ordinal::leq::{{{$filters.Ordinal}}}/$F2/Object_Ends_At_Ordinal:=(Ends_At)=(Vocabulary:Developmental_Stage:Name)/Ordinal::geq::{{{$filters.Ordinal}}}/$F1/F1I:=left(Schematic)=(Schematics:Schematic:RID)/$F2/F2I:=left(Schematic)=(Schematics:Schematic:RID)/$M/child_id:=M:Subject,parent_id:=M:Object,child:=F1:Name,parent:=F2:Name,child_image:=F1I:Schematic_URL,parent_image:=F2I:Schematic_URL",
+              tree_schema_table: "Vocabulary:Anatomy_Part_Of_Relationship", // for logging purposes
+              isolated_nodes_query: "/ermrest/catalog/2/attribute/t:=Vocabulary:Anatomy/start:=(Starts_At)=(Vocabulary:Developmental_Stage:Name)/start:Ordinal::leq::{{{$filters.Ordinal}}}/$t/end:=(Ends_At)=(Vocabulary:Developmental_Stage:Name)/end:Ordinal::geq::{{{$filters.Ordinal}}}/$t/s:=left(ID)=(Vocabulary:Anatomy_Part_Of_Relationship:Subject)/Subject::null::/$t/o:=left(ID)=(Vocabulary:Anatomy_Part_Of_Relationship:Object)/Object::null::/$t/I:=left(Schematic)=(Schematics:Schematic:RID)/$t/id:=t:ID,dbxref:=t:ID,name:=t:Name,t:Starts_At,t:Ends_At,image:=I:Schematic_URL",
+              isolated_schema_table: "Vocabulary:Anatomy", // for logging purposes
+          }
       ],
 
       hide_id: false, // default is false
@@ -98,93 +92,92 @@ var treeviewConfigs = {
       and  s."Subject" IS NULL and o."Object" is null;
       */
 
-    },
+  },
 
-    // extra attributes to annotate nodes with icons
-    annotation: {
+  // extra attributes to annotate nodes with icons
+  annotation: {
       annotation_query_pattern: "/ermrest/catalog/2/attributegroup/Gene_Expression:Specimen_Expression/Specimen={{{$url_parameters.Specimen_RID}}}/id:=Region,Region:=Region,strength:=Strength,strengthModifier:=Strength_Modifier,pattern:=Pattern,density:=Density,densityChange:=Density_Direction,densityMagnitude:=Density_Magnitude,densityNote:=Density_Note,note:=Notes",
       schema_table: "Gene_Expression:Specimen_Expression", // for logging purposes
       // keys should map to the columns listed in extra_attributes_columns
       // inner keys should be the value of that column with icon location as the value
       extra_attributes_icons: {
-        strength: {
-          hide_label_display: false, // if null or not there, show label
-          before_text: true,
-          // mapping of label name and icon
-          labels: {
-            "not detected": "resources/images/ExpressionMapping/ExpressionStrengthsKey/notDetected.gif",
-            uncertain: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Uncertain.gif",
-            present: {
-              strengthModifier: {
-                labels: {
-                  strong: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Present(strong).gif",
-                  moderate: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Present(moderate).gif",
-                  weak: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Present(weak).gif",
-                  default: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Present(unspecifiedStrength).gif"
-                }
-              },
-            }
-          }
-        },
-        density: {
-          hide_label_display: false,
-          before_text: false,
-          labels: {
-            High: "resources/images/NerveDensity/RelativeToTotal/high.png",
-            Low: "resources/images/NerveDensity/RelativeToTotal/low.png",
-            Medium: "resources/images/NerveDensity/RelativeToTotal/medium.png"
-          }
-        },
-        pattern: {
-          hide_label_display: false,
-          before_text: false,
-          labels: {
-            graded: "resources/images/ExpressionMapping/ExpressionPatternKey/Graded.png",
-            homogeneous: "resources/images/ExpressionMapping/ExpressionPatternKey/Homogeneous.png",
-            regional: "resources/images/ExpressionMapping/ExpressionPatternKey/Regional.png",
-            restricted: "resources/images/ExpressionMapping/ExpressionPatternKey/Restricted.png",
-            "single cell": "resources/images/ExpressionMapping/ExpressionPatternKey/SingleCell.png",
-            spotted: "resources/images/ExpressionMapping/ExpressionPatternKey/Spotted.png",
-            ubiquitous: "resources/images/ExpressionMapping/ExpressionPatternKey/Ubiquitous.png"
-          }
-        },
-        densityChange: {
-          hide_label_display: false,
-          before_text: false,
-          labels: {
-            Decreased: {
-              densityMagnitude: {
-                labels: {
-                  Large: "resources/images/NerveDensity/RelativeToP0/dec_large.png",
-                  Small: "resources/images/NerveDensity/RelativeToP0/dec_small.png",
-                  default: "resources/images/NerveDensity/RelativeToP0/dec_small.png"  // else case (including null)
-                }
+          strength: {
+              hide_label_display: false, // if null or not there, show label
+              before_text: true,
+              // mapping of label name and icon
+              labels: {
+                  "not detected": "resources/images/ExpressionMapping/ExpressionStrengthsKey/notDetected.gif",
+                  uncertain: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Uncertain.gif",
+                  present: {
+                      strengthModifier: {
+                          labels: {
+                              strong: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Present(strong).gif",
+                              moderate: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Present(moderate).gif",
+                              weak: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Present(weak).gif",
+                              default: "resources/images/ExpressionMapping/ExpressionStrengthsKey/Present(unspecifiedStrength).gif"
+                          }
+                      },
+                  }
               }
-            },
-            Increased: {
-              densityMagnitude: {
-                labels: {
-                  Large: "resources/images/NerveDensity/RelativeToP0/inc_large.png",
-                  Small: "resources/images/NerveDensity/RelativeToP0/inc_small.png",
-                  default: "resources/images/NerveDensity/RelativeToP0/inc_small.png"
-                }
+          },
+          density: {
+              hide_label_display: false,
+              before_text: false,
+              labels: {
+                  High: "resources/images/NerveDensity/RelativeToTotal/high.png",
+                  Low: "resources/images/NerveDensity/RelativeToTotal/low.png",
+                  Medium: "resources/images/NerveDensity/RelativeToTotal/medium.png"
               }
-            }
+          },
+          pattern: {
+              hide_label_display: false,
+              before_text: false,
+              labels: {
+                  graded: "resources/images/ExpressionMapping/ExpressionPatternKey/Graded.png",
+                  homogeneous: "resources/images/ExpressionMapping/ExpressionPatternKey/Homogeneous.png",
+                  regional: "resources/images/ExpressionMapping/ExpressionPatternKey/Regional.png",
+                  restricted: "resources/images/ExpressionMapping/ExpressionPatternKey/Restricted.png",
+                  "single cell": "resources/images/ExpressionMapping/ExpressionPatternKey/SingleCell.png",
+                  spotted: "resources/images/ExpressionMapping/ExpressionPatternKey/Spotted.png",
+                  ubiquitous: "resources/images/ExpressionMapping/ExpressionPatternKey/Ubiquitous.png"
+              }
+          },
+          densityChange: {
+              hide_label_display: false,
+              before_text: false,
+              labels: {
+                  Decreased: {
+                      densityMagnitude: {
+                          labels: {
+                              Large: "resources/images/NerveDensity/RelativeToP0/dec_large.png",
+                              Small: "resources/images/NerveDensity/RelativeToP0/dec_small.png",
+                              default: "resources/images/NerveDensity/RelativeToP0/dec_small.png"  // else case (including null)
+                          }
+                      }
+                  },
+                  Increased: {
+                      densityMagnitude: {
+                          labels: {
+                              Large: "resources/images/NerveDensity/RelativeToP0/inc_large.png",
+                              Small: "resources/images/NerveDensity/RelativeToP0/inc_small.png",
+                              default: "resources/images/NerveDensity/RelativeToP0/inc_small.png"
+                          }
+                      }
+                  }
+              }
+          },
+          densityNote: {
+              hide_label_display: false,
+              before_text: false,
+              has_tooltip: true,
+              labels: "resources/images/NerveDensity/note.gif"
+          },
+          note: {
+              hide_label_display: false,
+              before_text: false,
+              has_tooltip: true,
+              labels: "resources/images/NerveDensity/note.gif"
           }
-        },
-        densityNote: {
-          hide_label_display: false,
-          before_text: false,
-          has_tooltip: true,
-          labels: "resources/images/NerveDensity/note.gif"
-        },
-        note: {
-          hide_label_display: false,
-          before_text: false,
-          has_tooltip: true,
-          labels: "resources/images/NerveDensity/note.gif"
-        }
       }
-    }
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@isrd-isi-edu/chaise": "^0.0.24",
-        "@mui/material": "^5.13.6",
-        "@mui/x-tree-view": "^6.17.0",
+        "@mui/material": "^6.0.0",
+        "@mui/x-tree-view": "^7.23.2",
         "papaparse": "^5.4.1",
         "plotly.js-cartesian-dist-min": "^2.18.2",
         "react-grid-layout": "^1.3.4",
-        "react-select": "^5.7.0",
-        "react-window": "^1.8.8"
+        "react-select": "^5.9.0",
+        "react-window": "^1.8.11"
       },
       "devDependencies": {
         "@types/papaparse": "^5.3.7",
@@ -1738,13 +1738,13 @@
       }
     },
     "node_modules/@emotion/cache": {
-      "version": "11.13.1",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
-      "integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
         "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
       }
@@ -1791,14 +1791,14 @@
       }
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.2.tgz",
-      "integrity": "sha512-grVnMvVPK9yUVE6rkKfAJlYZgo0cu3l9iMC77V7DW6E1DUIrU68pSEXRmFZFOFB1QFo57TncmOcvcbMDWsL4yA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
       "dependencies": {
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
         "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.1",
+        "@emotion/utils": "^1.4.2",
         "csstype": "^3.0.2"
       }
     },
@@ -1843,9 +1843,9 @@
       }
     },
     "node_modules/@emotion/utils": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.1.tgz",
-      "integrity": "sha512-BymCXzCG3r72VKJxaYVwOXATqXIZ85cuvg0YOUDxMGNrKc1DJRZk8MgV5wyXRyEayIMd4FuXJIUgTBXvDNW5cA=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
@@ -1941,18 +1941,6 @@
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
         "@floating-ui/utils": "^0.2.8"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/utils": {
@@ -2207,18 +2195,32 @@
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "peer": true
     },
-    "node_modules/@mui/base": {
-      "version": "5.0.0-beta.61",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.61.tgz",
-      "integrity": "sha512-YaMOTXS3ecDNGsPKa6UdlJ8loFLvcL9+VbpCK3hfk71OaNauZRp4Yf7KeXDYr7Ms3M/XBD3SaiR6JMr6vYtfDg==",
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.3.1.tgz",
+      "integrity": "sha512-2OmnEyoHpj5//dJJpMuxOeLItCCHdf99pjMFfUFdBteCunAK9jW+PwEo4mtdGcLs7P+IgZ+85ypd52eY4AigoQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.3.1.tgz",
+      "integrity": "sha512-ynG9ayhxgCsHJ/dtDcT1v78/r2GwQyP3E0hPz3GdPRl0uFJz/uUTtI5KFYwadXmbC+Uv3bfB8laZ6+Cpzh03gA==",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@floating-ui/react-dom": "^2.1.1",
-        "@mui/types": "^7.2.19",
-        "@mui/utils": "^6.1.6",
+        "@mui/core-downloads-tracker": "^6.3.1",
+        "@mui/system": "^6.3.1",
+        "@mui/types": "^7.2.21",
+        "@mui/utils": "^6.3.1",
         "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0",
+        "react-transition-group": "^4.4.5"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2228,27 +2230,36 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^6.3.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         }
       }
     },
-    "node_modules/@mui/base/node_modules/@mui/utils": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.1.6.tgz",
-      "integrity": "sha512-sBS6D9mJECtELASLM+18WUcXF6RH3zNxBRFeyCRg8wad6NbyNrdxLuwK+Ikvc38sTZwBzAz691HmSofLqHd9sQ==",
+    "node_modules/@mui/private-theming": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.3.1.tgz",
+      "integrity": "sha512-g0u7hIUkmXmmrmmf5gdDYv9zdAig0KoxhIQn1JN8IVqApzf/AyRhH3uDGx5mSvs8+a1zb4+0W6LC260SyTTtdQ==",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/types": "^7.2.19",
-        "@types/prop-types": "^15.7.13",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.3.1"
+        "@mui/utils": "^6.3.1",
+        "prop-types": "^15.8.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2267,97 +2278,20 @@
         }
       }
     },
-    "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.7.tgz",
-      "integrity": "sha512-RtsCt4Geed2/v74sbihWzzRs+HsIQCfclHeORh5Ynu2fS4icIKozcSubwuG7vtzq2uW3fOR1zITSP84TNt2GoQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "node_modules/@mui/material": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.16.7.tgz",
-      "integrity": "sha512-cwwVQxBhK60OIOqZOVLFt55t01zmarKJiJUWbk0+8s/Ix5IaUzAShqlJchxsIQ4mSrWqgcKCCXKtIlG5H+/Jmg==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.16.7",
-        "@mui/system": "^5.16.7",
-        "@mui/types": "^7.2.15",
-        "@mui/utils": "^5.16.6",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.3.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/private-theming": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.6.tgz",
-      "integrity": "sha512-rAk+Rh8Clg7Cd7shZhyt2HGTTE5wYKNSJ5sspf28Fqm/PZ69Er9o6KX25g03/FG2dfpg5GCwZh/xOojiTfm3hw==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.16.6",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mui/styled-engine": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.6.tgz",
-      "integrity": "sha512-zaThmS67ZmtHSWToTiHslbI8jwrmITcN93LQaR2lKArbvS7Z3iLkwRoiikNWutx9MBs8Q6okKvbZq1RQYB3v7g==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.3.1.tgz",
+      "integrity": "sha512-/7CC0d2fIeiUxN5kCCwYu4AWUDd9cCTxWCyo0v/Rnv6s8uk6hWgJC3VLZBoDENBHf/KjqDZuYJ2CR+7hD6QYww==",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.11.0",
+        "@babel/runtime": "^7.26.0",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2366,7 +2300,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.4.1",
         "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -2378,21 +2312,21 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.7.tgz",
-      "integrity": "sha512-Jncvs/r/d/itkxh7O7opOunTqbbSSzMTHzZkNLM+FjAOg+cYAZHrPDlYe1ZGKUYORwwb2XexlWnpZp0kZ4AHuA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.3.1.tgz",
+      "integrity": "sha512-AwqQ3EAIT2np85ki+N15fF0lFXX1iFPqenCzVOSl3QXKy2eifZeGd9dGtt7pGMoFw5dzW4dRGGzRpLAq9rkl7A==",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.16.6",
-        "@mui/styled-engine": "^5.16.6",
-        "@mui/types": "^7.2.15",
-        "@mui/utils": "^5.16.6",
-        "clsx": "^2.1.0",
+        "@babel/runtime": "^7.26.0",
+        "@mui/private-theming": "^6.3.1",
+        "@mui/styled-engine": "^6.3.1",
+        "@mui/types": "^7.2.21",
+        "@mui/utils": "^6.3.1",
+        "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2401,8 +2335,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -2417,9 +2351,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.19",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.19.tgz",
-      "integrity": "sha512-6XpZEM/Q3epK9RN8ENoXuygnqUQxE+siN/6rGRi2iwJPgBUR25mphYQ9ZI87plGh58YoZ5pp40bFvKYOCDJ3tA==",
+      "version": "7.2.21",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.21.tgz",
+      "integrity": "sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -2430,27 +2364,27 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.6.tgz",
-      "integrity": "sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.3.1.tgz",
+      "integrity": "sha512-sjGjXAngoio6lniQZKJ5zGfjm+LD2wvLwco7FbKe1fu8A7VIFmz2SwkLb+MDPLNX1lE7IscvNNyh1pobtZg2tw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/types": "^7.2.15",
-        "@types/prop-types": "^15.7.12",
+        "@babel/runtime": "^7.26.0",
+        "@mui/types": "^7.2.21",
+        "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^18.3.1"
+        "react-is": "^19.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -2458,16 +2392,35 @@
         }
       }
     },
-    "node_modules/@mui/x-tree-view": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-6.17.0.tgz",
-      "integrity": "sha512-09dc2D+Rjg2z8KOaxbUXyPi0aw7fm2jurEtV8Xw48xJ00joLWd5QJm1/v4CarEvaiyhTQzHImNqdgeJW8ZQB6g==",
+    "node_modules/@mui/x-internals": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.23.0.tgz",
+      "integrity": "sha512-bPclKpqUiJYIHqmTxSzMVZi6MH51cQsn5U+8jskaTlo3J4QiMeCYJn/gn7YbeR9GOZFp8hetyHjoQoVHKRXCig==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/base": "^5.0.0-beta.20",
-        "@mui/utils": "^5.14.14",
-        "@types/react-transition-group": "^4.4.8",
-        "clsx": "^2.0.0",
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-tree-view": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-7.23.2.tgz",
+      "integrity": "sha512-/R/9/GSF311fVLOUCg7r+a/+AScYZezL0SJZPfsTOquL1RDPAFRZei7BZEivUzOSEELJc0cxLGapJyM6QCA7Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0",
+        "@mui/x-internals": "7.23.0",
+        "@types/react-transition-group": "^4.4.11",
+        "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
         "react-transition-group": "^4.4.5"
       },
@@ -2476,15 +2429,23 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.8.6",
-        "@mui/system": "^5.8.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@mui/material": "^5.15.14 || ^6.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3169,9 +3130,9 @@
       }
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.13",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA=="
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "node_modules/@types/q": {
       "version": "1.5.8",
@@ -3234,10 +3195,10 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
-      "integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
-      "dependencies": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -8317,9 +8278,9 @@
       "peer": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -9412,9 +9373,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -9475,9 +9436,9 @@
       }
     },
     "node_modules/react-select": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.2.tgz",
-      "integrity": "sha512-a/LkOckoI62710gGPQSQqUp7A10fGbH/ya3/IR49qaq3XoBvwymgD5mJgtiHxBDsutyEQfdKNycWVh8Cg8UCjw==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.9.0.tgz",
+      "integrity": "sha512-nwRKGanVHGjdccsnzhFte/PULziueZxGD8LL2WojON78Mvnq7LdAMEtu2frrwld1fr3geixg3iiMBIc/LLAZpw==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -9487,11 +9448,11 @@
         "memoize-one": "^6.0.0",
         "prop-types": "^15.6.0",
         "react-transition-group": "^4.3.0",
-        "use-isomorphic-layout-effect": "^1.1.2"
+        "use-isomorphic-layout-effect": "^1.2.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-transition-group": {
@@ -9510,9 +9471,9 @@
       }
     },
     "node_modules/react-window": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
-      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": ">=3.1.1 <6"
@@ -9521,8 +9482,8 @@
         "node": ">8.0.0"
       },
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-window/node_modules/memoize-one": {
@@ -11102,11 +11063,11 @@
       }
     },
     "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
+      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@isrd-isi-edu/chaise": "^0.0.24",
-    "@mui/material": "^5.13.6",
-    "@mui/x-tree-view": "^6.17.0",
+    "@mui/material": "^6.0.0",
+    "@mui/x-tree-view": "^7.23.2",
     "papaparse": "^5.4.1",
     "plotly.js-cartesian-dist-min": "^2.18.2",
     "react-grid-layout": "^1.3.4",
-    "react-select": "^5.7.0",
-    "react-window": "^1.8.8"
+    "react-select": "^5.9.0",
+    "react-window": "^1.8.11"
   }
 }

--- a/src/components/boolean-search/boolean-table.tsx
+++ b/src/components/boolean-search/boolean-table.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import { windowRef } from '@isrd-isi-edu/deriva-webapps/src/utils/window-ref';
 import { getDefaultValues  } from '@isrd-isi-edu/deriva-webapps/src/hooks/boolean-search';
 export type BooleanTableProps = {

--- a/src/components/matrix/column-tree-headers.tsx
+++ b/src/components/matrix/column-tree-headers.tsx
@@ -176,7 +176,7 @@ const ColumnHeaders = (props: ColumnHeadersProps, ref: ForwardedRef<any>): JSX.E
             expandedItems={expanded}
             onExpandedItemsChange={handleToggle}
             ref={divRef}
-            style={{
+            sx={{
               position: 'absolute',
               /**
                * For vertical scrolling function of the horizontal tree, we only want to scroll up. But after using
@@ -193,8 +193,8 @@ const ColumnHeaders = (props: ColumnHeadersProps, ref: ForwardedRef<any>): JSX.E
                * So we add a paddingBottom attribute as the style of the tree manually.
                */
               paddingBottom: props.cellWidth + getScrollbarSize('.grid'),
+              overflow: 'clip'
             }}
-            sx={{ overflow: 'clip' }}
           >
             <MemoizedRenderTree
               nodes={props.treeNodes}

--- a/src/components/matrix/column-tree-headers.tsx
+++ b/src/components/matrix/column-tree-headers.tsx
@@ -4,17 +4,16 @@ import { memo, forwardRef, ForwardedRef, CSSProperties, useState, useEffect, use
 import SharedColumnHeaders, { SharedColumnHeadersProps } from '@isrd-isi-edu/deriva-webapps/src/components/matrix//shared-column-headers';
 
 // Data type used for treeview
-import { ParsedGridCell } from '@isrd-isi-edu/deriva-webapps/src/hooks/matrix';
-import { MatrixTreeDatum } from '@isrd-isi-edu/deriva-webapps/src/hooks/matrix';
-import { TreeNode } from '@isrd-isi-edu/deriva-webapps/src/hooks/matrix';
-import { TreeNodeMap } from '@isrd-isi-edu/deriva-webapps/src/hooks/matrix';
+import { ParsedGridCell, MatrixTreeDatum, TreeNode, TreeNodeMap } from '@isrd-isi-edu/deriva-webapps/src/hooks/matrix';
 
 // Tree functions and sub components
 import { checkParentChainExist, getParentChain } from '@isrd-isi-edu/deriva-webapps/src/utils/tree';
-import { MemoizedMinusSquare, MemoizedPlusSquare, MemoizedCloseSquare, MemoizedRenderTree } from '@isrd-isi-edu/deriva-webapps/src/components/matrix/tree-button';
+import {
+  MemoizedMinusSquare, MemoizedPlusSquare, MemoizedCloseSquare, MemoizedRenderTree
+} from '@isrd-isi-edu/deriva-webapps/src/components/matrix/tree-button';
 
 // MUI tree components
-import { TreeView } from '@mui/x-tree-view/TreeView';
+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 
 import { getScrollbarSize } from '@isrd-isi-edu/deriva-webapps/src/utils/ui-utils';
 
@@ -107,10 +106,10 @@ const ColumnHeaders = (props: ColumnHeadersProps, ref: ForwardedRef<any>): JSX.E
     }
     // Check visibility and add all visiable nodes to the set
     const nodesSet: Set<string> = new Set(expanded);
-    expanded.forEach(nodeId => {
-      const visible = checkParentChainExist(treeDataDict, nodeId, nodesSet);
+    expanded.forEach(itemId => {
+      const visible = checkParentChainExist(treeDataDict, itemId, nodesSet);
       if (!visible) return;
-      const node = props.treeNodesMap[nodeId];
+      const node = props.treeNodesMap[itemId];
       if (!node || node.children.length === 0) return;
       if (node.children.length > 0) {
         for (const child of node.children) {
@@ -147,8 +146,8 @@ const ColumnHeaders = (props: ColumnHeadersProps, ref: ForwardedRef<any>): JSX.E
   /**
    * Handle toggle in tree view
    */
-  const handleToggle = (event: React.SyntheticEvent, nodeIds: string[]) => {
-    setExpanded(nodeIds);
+  const handleToggle = (event: React.SyntheticEvent, itemIds: string[]) => {
+    setExpanded(itemIds);
   };
 
   return (
@@ -165,15 +164,17 @@ const ColumnHeaders = (props: ColumnHeadersProps, ref: ForwardedRef<any>): JSX.E
             transform: 'rotate(-90deg)',
           }}>
 
-          <TreeView
+          <SimpleTreeView
             className='grid-column-headers-treeview'
             aria-label='rich object'
-            defaultExpanded={['root']}
-            defaultCollapseIcon={<MemoizedMinusSquare isLeft={true} cellSize={props.cellWidth} iconSize={iconSize} />}
-            defaultExpandIcon={<MemoizedPlusSquare isLeft={true} cellSize={props.cellWidth} iconSize={iconSize} />}
-            defaultEndIcon={<MemoizedCloseSquare isLeft={true} cellSize={props.cellWidth} />}
-            expanded={expanded}
-            onNodeToggle={handleToggle}
+            defaultExpandedItems={['root']}
+            slots={{
+              collapseIcon: () => <MemoizedMinusSquare isLeft={true} cellSize={props.cellWidth} iconSize={iconSize} />,
+              expandIcon: () => <MemoizedPlusSquare isLeft={true} cellSize={props.cellWidth} iconSize={iconSize} />,
+              endIcon: () => <MemoizedCloseSquare isLeft={true} cellSize={props.cellWidth} />
+            }}
+            expandedItems={expanded}
+            onExpandedItemsChange={handleToggle}
             ref={divRef}
             style={{
               position: 'absolute',
@@ -204,7 +205,7 @@ const ColumnHeaders = (props: ColumnHeadersProps, ref: ForwardedRef<any>): JSX.E
               scrollableSize={scrollableHeight}
               isColumn={true}
             />
-          </TreeView>
+          </SimpleTreeView>
         </div>
       </div>
     </SharedColumnHeaders>

--- a/src/components/matrix/row-tree-headers.tsx
+++ b/src/components/matrix/row-tree-headers.tsx
@@ -14,7 +14,7 @@ import {checkParentChainExist, getParentChain} from '@isrd-isi-edu/deriva-webapp
 import { MemoizedMinusSquare, MemoizedPlusSquare, MemoizedCloseSquare, MemoizedRenderTree } from '@isrd-isi-edu/deriva-webapps/src/components/matrix/tree-button';
 
 // MUI tree components
-import { TreeView } from '@mui/x-tree-view/TreeView';
+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 
 import { getScrollbarSize } from '@isrd-isi-edu/deriva-webapps/src/utils/ui-utils';
 
@@ -107,10 +107,10 @@ const RowTreeHeaders = (props: RowHeadersProps, ref: ForwardedRef<any>): JSX.Ele
     }
     // Check visibility and add all visiable nodes to the set
     const nodesSet: Set<string> = new Set(expanded);
-    expanded.forEach(nodeId => {
-      const visible = checkParentChainExist(treeDataDict, nodeId, nodesSet);
+    expanded.forEach(itemId => {
+      const visible = checkParentChainExist(treeDataDict, itemId, nodesSet);
       if (!visible) return;
-      const node = props.treeNodesMap[nodeId];
+      const node = props.treeNodesMap[itemId];
       if (!node || node.children.length === 0) return;
       if (node.children.length > 0) {
         for (const child of node.children) {
@@ -150,8 +150,8 @@ const RowTreeHeaders = (props: RowHeadersProps, ref: ForwardedRef<any>): JSX.Ele
   /**
    * Handle toggle in tree view
    */
-  const handleToggle = (event: React.SyntheticEvent, nodeIds: string[]) => {
-    setExpanded(nodeIds);
+  const handleToggle = (event: React.SyntheticEvent, itemIds: string[]) => {
+    setExpanded(itemIds);
   };
 
   return (
@@ -163,15 +163,17 @@ const RowTreeHeaders = (props: RowHeadersProps, ref: ForwardedRef<any>): JSX.Ele
         ref={ref}
         onScroll={props.onScroll}>
 
-          <TreeView
+          <SimpleTreeView
             className='grid-row-headers-treeview'
             aria-label='rich object'
-            defaultExpanded={['root']}
-            defaultCollapseIcon={<MemoizedMinusSquare isLeft={false} cellSize={props.cellHeight} iconSize={iconSize} />}
-            defaultExpandIcon={<MemoizedPlusSquare isLeft={false} cellSize={props.cellHeight} iconSize={iconSize} />}
-            defaultEndIcon={<MemoizedCloseSquare isLeft={false} cellSize={props.cellHeight} />}
-            expanded={expanded}
-            onNodeToggle={handleToggle}
+            defaultExpandedItems={['root']}
+            slots={{
+              collapseIcon: () => <MemoizedMinusSquare isLeft={false} cellSize={props.cellHeight} iconSize={iconSize} />,
+              expandIcon: () => <MemoizedPlusSquare isLeft={false} cellSize={props.cellHeight} iconSize={iconSize} />,
+              endIcon: () => <MemoizedCloseSquare isLeft={false} cellSize={props.cellHeight} />
+            }}
+            expandedItems={expanded}
+            onExpandedItemsChange={handleToggle}
             ref={divRef}
           >
             <MemoizedRenderTree
@@ -183,7 +185,7 @@ const RowTreeHeaders = (props: RowHeadersProps, ref: ForwardedRef<any>): JSX.Ele
               scrollableSize={scrollableWidth}
               isColumn={false}
             />
-          </TreeView>
+          </SimpleTreeView>
           {/* For the highlight alignment issue, we're adding empty cells and headers in the falt row headers.
             But Mui is ignoring the empty tree elements. So we add an element after trees manually */}
           <div style={{ height: props.cellHeight + getScrollbarSize('.grid', true) }}></div>

--- a/src/components/matrix/tree-button.tsx
+++ b/src/components/matrix/tree-button.tsx
@@ -6,7 +6,7 @@ import { TreeNodeMap } from '@isrd-isi-edu/deriva-webapps/src/hooks/matrix';
 
 // MUI tree components
 import { alpha, styled } from '@mui/material/styles';
-import { TreeItem, TreeItemProps, treeItemClasses, useTreeItem, TreeItemContentProps } from '@mui/x-tree-view/TreeItem';
+import { TreeItem, TreeItemProps, treeItemClasses, useTreeItemState, TreeItemContentProps } from '@mui/x-tree-view/TreeItem';
 import clsx from 'clsx';
 import Typography from '@mui/material/Typography';
 
@@ -302,19 +302,19 @@ export const MemoizedRenderTree = memo(({ nodes, data, cellSize, treeNodesMap, i
   /**
    * Update id or index for when hover an item (row header)
    */
-  const updateRowId = (nodeId: string) => {
+  const updateRowId = (itemId: string) => {
     if (!isScrolling) {
       setHoveredColID(null);
-      setHoveredRowID(nodeId);
+      setHoveredRowID(itemId);
     }
   };
 
   /**
    * Update id or index for when hover an item (column header)
    */
-  const updateColId = (nodeId: string) => {
+  const updateColId = (itemId: string) => {
     if (!isScrolling) {
-      setHoveredColID(nodeId);
+      setHoveredColID(itemId);
       setHoveredRowID(null);
     }
   };
@@ -330,7 +330,7 @@ export const MemoizedRenderTree = memo(({ nodes, data, cellSize, treeNodesMap, i
       classes,
       className,
       label,
-      nodeId,
+      itemId,
       icon: iconProp,
       expansionIcon,
       displayIcon
@@ -344,7 +344,7 @@ export const MemoizedRenderTree = memo(({ nodes, data, cellSize, treeNodesMap, i
       handleExpansion,
       handleSelection,
       preventSelection
-    } = useTreeItem(nodeId);
+    } = useTreeItemState(itemId);
 
     const icon = iconProp || expansionIcon || displayIcon;
 
@@ -366,14 +366,14 @@ export const MemoizedRenderTree = memo(({ nodes, data, cellSize, treeNodesMap, i
       handleSelection(event);
     };
 
-    const link = treeNodesMap[nodeId].link;
+    const link = treeNodesMap[itemId].link;
 
-    const hover = isColumn ? nodeId === hoveredColID : nodeId === hoveredRowID
+    const hover = isColumn ? itemId === hoveredColID : itemId === hoveredRowID
     const linkClassName = hover ? 'hovered-header' : 'unhovered-header';
 
     const onMouseEnterHandler = isColumn
-      ? () => updateColId(nodeId)
-      : () => updateRowId(nodeId);
+      ? () => updateColId(itemId)
+      : () => updateRowId(itemId);
 
     return (
       <div
@@ -445,7 +445,7 @@ export const MemoizedRenderTree = memo(({ nodes, data, cellSize, treeNodesMap, i
         opacity: 0.3
       }
     },
-    [`& .${treeItemClasses.group}`]: isColumn
+    [`& .${treeItemClasses.groupTransition}`]: isColumn
     ? {
       marginLeft: 15,
       paddingLeft: 4,
@@ -482,7 +482,7 @@ export const MemoizedRenderTree = memo(({ nodes, data, cellSize, treeNodesMap, i
     return nodes.map((node) => (
       <StyledTreeItem
         key={node.link}
-        nodeId={node.key}
+        itemId={node.key}
         label={node.title}
         className='MUI-tree'
         node={node}

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -4,8 +4,8 @@ import { MatrixTreeDatum } from '@isrd-isi-edu/deriva-webapps/src/hooks/matrix';
 /**
  * Check whether all ancestors of a node exist in visitedNode list
  */
-export const checkParentChainExist = (treeDataDict: Record<string, MatrixTreeDatum>, nodeId: string, visitedNodes: Set<string>): boolean => {
-  const node = treeDataDict[nodeId];
+export const checkParentChainExist = (treeDataDict: Record<string, MatrixTreeDatum>, itemId: string, visitedNodes: Set<string>): boolean => {
+  const node = treeDataDict[itemId];
   if (node.parent_id === null) {
     return true; // Reached the top of the chain
   }
@@ -18,8 +18,8 @@ export const checkParentChainExist = (treeDataDict: Record<string, MatrixTreeDat
 /**
  * Find all ancestor nodes of the searched node
  */
-export const getParentChain = (treeDataDict: Record<string, MatrixTreeDatum>, nodeId: string, visitedNodes: Set<string>): Set<string> => {
-  let node = treeDataDict[nodeId];
+export const getParentChain = (treeDataDict: Record<string, MatrixTreeDatum>, itemId: string, visitedNodes: Set<string>): Set<string> => {
+  let node = treeDataDict[itemId];
   if (node.parent_id === null) {
     return visitedNodes; // Reached the top of the chain
   }

--- a/src/utils/ui-utils.ts
+++ b/src/utils/ui-utils.ts
@@ -92,7 +92,7 @@ export function addBottomHorizontalScroll(content: HTMLElement, treeviewAuto: bo
     }
   }
 
-  const sensors = [];
+  const sensors : ResizeSensor[] = [];
 
   // make sure that the length of the scroll is identical to the scroll at the bottom of the table
   sensors.push(new ResizeSensor(scrollableContent, setTopScrollStyles));
@@ -213,7 +213,7 @@ export function addRightVerticalScroll(content: HTMLElement, treeviewAuto: boole
     }, 100); // This slight delay ensures that the rendering is complete.
   }
 
-  const sensors = [];
+  const sensors : ResizeSensor[] = [];
 
   // make sure that the length of the scroll is identical to the scroll at the bottom of the table
   sensors.push(new ResizeSensor(scrollableContent, setTopScrollStyles));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
       "DOM",
       "ESNext"
     ],
-    "allowJs": true,                             /* Allow javascript files to be compiled. */
+    // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     "jsx": "react-jsx",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                            /* Generates corresponding '.d.ts' file. */


### PR DESCRIPTION
This PR will update all the dependencies that didn't support React 19, to the version that allows React 19. The dependencies are,

- `react-select`
- `react-window`
- `@mui/material`
- `@mui/x-tree-view`

The first two didn't require any code changes, but for the last two I had to make some changes to the matrix app code.

@KenyShah24 Please test the apps (except matrix) and make sure there isn't any regression. I launched the staging.atlas-d2k.org so we can test these apps.


